### PR TITLE
Move rollup to peerDependencies and bump to 0.40.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "url": "https://github.com/permutatrix/rollup-stream/issues"
   },
   "homepage": "https://github.com/permutatrix/rollup-stream#readme",
-  "dependencies": {
-    "rollup": "^0.38.0"
+  "peerDependencies": {
+    "rollup": "^0.40.2"
   },
   "devDependencies": {
     "chai": "^3.4.1",


### PR DESCRIPTION
In latest `rollup-stream@1.16.0`, it depends on `rollup@0.38.0`.

But it seems `rollup@0.38.0` got a bug that failed to compile React (error log attached). But the bug does not repro in `rollup@<=0.37.2` or `rollup@>=0.40.2`.

I would like to bump `rollup` version from `0.38.0` to `0.40.2`. But since `rollup-stream@1.16.0` is depending on a specific version of `rollup@0.38.0`. This means `rollup` is being bundled in `rollup-stream` and makes bumping `rollup` version impossible.

I am suggesting to change `rollup` dependency type from direct into [peer dependencies](https://nodejs.org/en/blog/npm/peer-dependencies/). This will help developers to choose a compatible version of `rollup`.

Moreover, the latest `rollup@0.40.2` seems working fine with `rollup-stream@1.16.0`, all Mocha tests are passed. So I also bumped `rollup` version from `0.38.0` to `0.40.2`.

For your reference, the following is the error from `rollup@0.38.0`.

```
TypeError: Cannot read property 'findDeclaration' of undefined
    at callHasEffects (C:\Users\Compulim\Source\Repos\cnr-modern-web-template.buddy\node_modules\rollup\dist\rollup.js:5887:27)
    at CallExpression.hasEffects (C:\Users\Compulim\Source\Repos\cnr-modern-web-template.buddy\node_modules\rollup\dist\rollup.js:5948:10)
    at CallExpression.isUsedByBundle (C:\Users\Compulim\Source\Repos\cnr-modern-web-template.buddy\node_modules\rollup\dist\rollup.js:5959:15)
    at C:\Users\Compulim\Source\Repos\cnr-modern-web-template.buddy\node_modules\rollup\dist\rollup.js:9021:30
```

