### PR TITLE
Upgraded Rollup to 0.49.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - '0.12'
   - '4'
   - '5'
   - '6'

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ var gulp = require('gulp'),
 
 gulp.task('rollup', function() {
   return rollup({
-      entry: './src/main.js'
+      input: './src/main.js'
     })
     
     // give the file the name you want to output with.
@@ -42,7 +42,7 @@ var gulp = require('gulp'),
 
 gulp.task('rollup', function() {
   return rollup({
-      entry: './src/main.js',
+      input: './src/main.js',
       sourceMap: true
     })
     
@@ -77,7 +77,7 @@ var gulp = require('gulp'),
 var cache;
 gulp.task('rollup', function() {
   return rollup({
-      entry: './src/main.js',
+      input: './src/main.js',
       cache: cache
     })
     
@@ -103,7 +103,7 @@ var gulp = require('gulp'),
 
 gulp.task('rollup', function() {
   return rollup({
-      entry: './src/main.js',
+      input: './src/main.js',
       rollup: require('rollup')
     })
     

--- a/index.js
+++ b/index.js
@@ -5,16 +5,8 @@ module.exports = function rollupStream(options) {
   var stream = new Readable();
   stream._read = function() {  };
   
-  var rollup = (options && options.rollup) || require('rollup');
-  
   if(typeof options === 'object' && options !== null) {
-    var options1 = {};
-    for(var key in options) {
-      if(key !== 'rollup') {
-        options1[key] = options[key];
-      }
-    }
-    options = Promise.resolve(options1);
+    options = Promise.resolve(options);
   } else if(typeof options === 'string') {
     var optionsPath = path.resolve(options);
     options = require('rollup').rollup({
@@ -48,7 +40,28 @@ module.exports = function rollupStream(options) {
     options = Promise.reject(Error("options must be an object or a string!"));
   }
   
-  options.then(function(options) {
+  options.then(function(options0) {
+    var rollup = options0.rollup;
+    var hasCustomRollup = true;
+    if(!rollup) {
+      rollup = require('rollup');
+      hasCustomRollup = false;
+    }
+    
+    var options = {};
+    for(var key in options0) {
+      if(key === 'sourceMap' && !hasCustomRollup) {
+        console.warn(
+          "The sourceMap option has been renamed to \"sourcemap\" " +
+          "(lowercase \"m\") in Rollup. The old form is now deprecated " +
+          "in rollup-stream."
+        );
+        options.sourcemap = options0.sourceMap;
+      } else if(key !== 'rollup') {
+        options[key] = options0[key];
+      }
+    }
+    
     return rollup.rollup(options).then(function(bundle) {
       stream.emit('bundle', bundle);
       
@@ -57,7 +70,7 @@ module.exports = function rollupStream(options) {
       var code = result.code, map = result.map;
       
       stream.push(code);
-      if(options.sourcemap) {
+      if(options.sourcemap || options.sourceMap) {
         stream.push('\n//# sourceMappingURL=');
         stream.push(map.toUrl());
       }

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = function rollupStream(options) {
   } else if(typeof options === 'string') {
     var optionsPath = path.resolve(options);
     options = require('rollup').rollup({
-      entry: optionsPath,
+      input: optionsPath,
       onwarn: function(warning) {
         if(warning.code !== 'UNRESOLVED_IMPORT') {
           console.warn(warning.message);
@@ -57,7 +57,7 @@ module.exports = function rollupStream(options) {
       var code = result.code, map = result.map;
       
       stream.push(code);
-      if(options.sourceMap) {
+      if(options.sourcemap) {
         stream.push('\n//# sourceMappingURL=');
         stream.push(map.toUrl());
       }
@@ -68,6 +68,6 @@ module.exports = function rollupStream(options) {
       stream.emit('error', reason);
     });
   });
-  
+
   return stream;
 };

--- a/index.js
+++ b/index.js
@@ -68,6 +68,6 @@ module.exports = function rollupStream(options) {
       stream.emit('error', reason);
     });
   });
-
+  
   return stream;
 };

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/permutatrix/rollup-stream#readme",
   "dependencies": {
-    "rollup": "^0.45.1"
+    "rollup": "^0.49.2"
   },
   "devDependencies": {
     "chai": "^3.4.1",

--- a/test/fixtures/config.js
+++ b/test/fixtures/config.js
@@ -1,7 +1,7 @@
 import hypothetical from 'rollup-plugin-hypothetical';
 
 export default {
-  entry: './entry.js',
+  input: './entry.js',
   format: 'es',
   plugins: [hypothetical({
     files: {

--- a/test/test.js
+++ b/test/test.js
@@ -176,6 +176,24 @@ describe("sourcemaps", function() {
     });
   });
   
+  it("should still be added when options.sourceMap is true", function() {
+    return collect(rollup({
+      input: './entry.js',
+      format: 'es',
+      sourceMap: true,
+      plugins: [{
+        resolveId: function(id) {
+          return id;
+        },
+        load: function() {
+          return 'console.log("Hello, World!");';
+        }
+      }]
+    })).then(function(data) {
+      expect(data).to.have.string('\n//# sourceMappingURL=data:application/json;');
+    });
+  });
+  
   it("should not be added otherwise", function() {
     return collect(rollup({
       input: './entry.js',

--- a/test/test.js
+++ b/test/test.js
@@ -39,10 +39,10 @@ describe("rollup-stream", function() {
     });
   });
   
-  it("should emit an error if options.entry isn't present", function(done) {
+  it("should emit an error if options.input isn't present", function(done) {
     var s = rollup({});
     s.on('error', function(err) {
-      expect(err.message).to.equal("You must supply options.entry to rollup");
+      expect(err.message).to.equal("You must supply options.input to rollup");
       done();
     });
     s.on('data', function() {
@@ -52,7 +52,7 @@ describe("rollup-stream", function() {
   
   it("should take a snapshot of options when the function is called", function() {
     var options = {
-      entry: './entry.js',
+      input : './entry.js',
       format: 'es',
       plugins: [hypothetical({
         files: {
@@ -89,7 +89,7 @@ describe("rollup-stream", function() {
   
   it("shouldn't raise an alarm when options.rollup is passed", function() {
     return collect(rollup({
-      entry: './entry.js',
+      input : './entry.js',
       format: 'es',
       rollup: require('rollup'),
       plugins: [{
@@ -124,7 +124,7 @@ describe("rollup-stream", function() {
   
   it("should emit a 'bundle' event when the bundle is output", function(done) {
     var s = rollup({
-      entry: './entry.js',
+      input : './entry.js',
       format: 'es',
       plugins: [{
         resolveId: function(id) {
@@ -158,11 +158,11 @@ describe("rollup-stream", function() {
 });
 
 describe("sourcemaps", function() {
-  it("should be added when options.sourceMap is true", function() {
+  it("should be added when options.sourcemap is true", function() {
     return collect(rollup({
-      entry: './entry.js',
+      input: './entry.js',
       format: 'es',
-      sourceMap: true,
+      sourcemap: true,
       plugins: [{
         resolveId: function(id) {
           return id;
@@ -178,7 +178,7 @@ describe("sourcemaps", function() {
   
   it("should not be added otherwise", function() {
     return collect(rollup({
-      entry: './entry.js',
+      input: './entry.js',
       format: 'es',
       plugins: [{
         resolveId: function(id) {


### PR DESCRIPTION
This was spitting out errors for me since the latest version of Rollup did some renaming of their options.

• Updated Rollup dependency from `^0.45.1` to `^0.45.1`.
• Renamed `entry` to `input` across the board, since `entry` throws a deprecation warning now.
• Changed `sourceMap` to `sourcemap`, because Rollup changed _that_ without a deprecation warning.
• Updated the docs and tests with the above info.