### PR TITLE
Update rollup's version to avoid error

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/permutatrix/rollup-stream#readme",
   "dependencies": {
-    "rollup": "^0.49.2"
+    "rollup": "^0.55.5"
   },
   "devDependencies": {
     "chai": "^3.4.1",


### PR DESCRIPTION
package.json needs to be updated to avoid this error

```
Error: You must specify options.format, which can be one of 'amd', 'cjs', 'es', 'iife' or 'umd'
    at error ({your_path}/node_modules/rollup-stream/node_modules/rollup/dist/rollup.js:185:14)
```